### PR TITLE
Use Android permission system

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,6 +4,13 @@
     android:versionCode="15"
     android:versionName="2.1.4" xmlns:tools="http://schemas.android.com/tools">
 
+    <permission-group android:name="de.robv.android.xposed.permissions"
+                      android:label="@string/xposed_permission_group" />
+
+    <permission android:name="de.robv.android.xposed.permission.USE_XPOSED"
+                android:permissionGroup="de.robv.android.xposed.permissions"
+                android:label="@string/xposed_permission" />
+
     <uses-sdk android:minSdkVersion="15" android:targetSdkVersion="15" tools:ignore="OldTargetApi"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_SUPERUSER"/>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -32,4 +32,6 @@
     <string name="app_process" translatable="false">app_process</string>
     <string name="xposedbridge" translatable="false">XposedBridge.jar</string>
     <string name="translator"></string>
+    <string name="xposed_permission_group">Xposed Framework Permission</string>
+    <string name="xposed_permission">Allow application to use Xposed to hook to existing applications (including system) codes.</string>
 </resources>


### PR DESCRIPTION
This is to allow seamless installation of modules (skipping the need to
go Xposed Installer to enable a module after installation).

This feature is backward compatible: modules without the permission
specified will require the manual activation of module.
