### PR TITLE
Allow external application to open a tab

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -31,7 +31,8 @@
         </activity>
         <activity
             android:name=".XposedInstallerActivity"
-            android:configChanges="orientation|screenSize" >
+            android:configChanges="orientation|screenSize"
+            android:exported="true">
         </activity>
 
         <receiver android:name=".PackageChangeReceiver" >


### PR DESCRIPTION
Without enabling android:export on XposedInstallerActivity external applications can't start that activity.
