### PR TITLE
Let's SimpleAdapter's context be Activity, not Application.

### DIFF
--- a/src/de/robv/android/xposed/installer/DownloadFragment.java
+++ b/src/de/robv/android/xposed/installer/DownloadFragment.java
@@ -66,7 +66,7 @@ public class DownloadFragment extends Fragment implements RepoListener, ModuleLi
 		mPref = XposedApp.getPreferences();
 		mRepoLoader = RepoLoader.getInstance();
 		mModuleUtil = ModuleUtil.getInstance();
-		mAdapter = new DownloadsAdapter(XposedApp.getInstance());
+		mAdapter = new DownloadsAdapter(getActivity());
 		mSortingOrder = mPref.getInt("download_sorting_order", SORT_STATUS);
 		setHasOptionsMenu(true);
 	}


### PR DESCRIPTION
`DownloadsAdapter` will inflate layout, and layout should be under
`Activity`. Actually, current `XposedApp.getInstance()` is an
`Application` context, which doesn't apply custom theme. (Back-ported
version need custom theme).

For more question of context, I think this article describes clearly:
http://www.doubleencore.com/2013/06/context/
