### PR TITLE
Allow module URLs to be opened in Xposed Installer

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -42,6 +42,12 @@
 			    <data android:scheme="package" />
 			    <category android:name="android.intent.category.DEFAULT" />
 			</intent-filter>
+			<intent-filter>
+			    <data android:scheme="http" android:host="repo.xposed.info" android:pathPrefix="/module" />
+			    <category android:name="android.intent.category.DEFAULT" />
+			    <category android:name="android.intent.category.BROWSABLE" />
+			    <action android:name="android.intent.action.VIEW" />
+			</intent-filter>
         </activity>
 
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -43,7 +43,7 @@
 			    <category android:name="android.intent.category.DEFAULT" />
 			</intent-filter>
 			<intent-filter>
-			    <data android:scheme="http" android:host="repo.xposed.info" android:pathPrefix="/module" />
+			    <data android:scheme="http" android:host="repo.xposed.info" android:pathPrefix="/module/" />
 			    <category android:name="android.intent.category.DEFAULT" />
 			    <category android:name="android.intent.category.BROWSABLE" />
 			    <action android:name="android.intent.action.VIEW" />

--- a/src/de/robv/android/xposed/installer/DownloadDetailsActivity.java
+++ b/src/de/robv/android/xposed/installer/DownloadDetailsActivity.java
@@ -8,8 +8,12 @@ public class DownloadDetailsActivity extends XposedDropdownNavActivity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-
-		String packageName = getIntent().getData().getSchemeSpecificPart();
+		String packageName;
+		if (Intent.ACTION_VIEW.equals(getIntent().getAction())) {
+			packageName = getIntent().getData().getPathSegments().get(1);
+		} else {
+			packageName = getIntent().getData().getSchemeSpecificPart();
+		}
 		DownloadDetailsFragment detailsFragment = DownloadDetailsFragment.newInstance(packageName);
 
 		FragmentTransaction tx = getFragmentManager().beginTransaction();

--- a/src/de/robv/android/xposed/installer/DownloadDetailsFragment.java
+++ b/src/de/robv/android/xposed/installer/DownloadDetailsFragment.java
@@ -67,7 +67,9 @@ public class DownloadDetailsFragment extends Fragment {
 
 		Bundle args = getArguments();
 		packageName = args.getString(ARGUMENT_PACKAGE);
-		moduleGroup = RepoLoader.getInstance().waitForFirstLoadFinished().getModuleGroup(packageName);
+		RepoLoader loader = RepoLoader.getInstance();
+		loader.triggerReload(true);
+		moduleGroup = loader.waitForFirstLoadFinished().getModuleGroup(packageName);
 		module = moduleGroup.getModule();
 
 		TextView title = (TextView) view.findViewById(R.id.download_title);


### PR DESCRIPTION
This patch allows Xposed Installer to show up as an option when a user clicks a module in the repo website.

This would allow devs to have links in XDA that would directly send the user to the Xposed Installer app.
Here's a screenshot: http://i.imgur.com/sB9bTJGl.png
