### PR TITLE
Filter out the Xposed Installer from the intent app chooser

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -4,6 +4,7 @@
     <!-- General/various strings -->
     <string name="menuSend">Send</string>
     <string name="menuSaveToSd">Save to SD card</string>
+    <string name="whichApplication">Complete action using</string>
     <string name="xposed_not_active">The latest version of Xposed is currently not active. Did you install the framework and reboot?</string>
 
     <!-- Welcome screen / main sections -->

--- a/src/de/robv/android/xposed/installer/util/NavUtil.java
+++ b/src/de/robv/android/xposed/installer/util/NavUtil.java
@@ -1,21 +1,25 @@
 package de.robv.android.xposed.installer.util;
 
 import android.app.Activity;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
-import android.provider.Browser;
+import android.os.Parcelable;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.style.URLSpan;
 import android.text.util.Linkify;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import de.robv.android.xposed.installer.R;
 import de.robv.android.xposed.installer.XposedBaseActivity;
 
 public final class NavUtil {
 	public static final String FINISH_ON_UP_NAVIGATION = "finish_on_up_navigation";
-	public static final Uri EXAMPLE_URI = Uri.fromParts("http", "//example.org", null);
+	private static final String XPOSED_INSTALLER_PACKAGE_NAME = "de.robv.android.xposed.installer";
 
 	public static void setTransitionSlideEnter(Activity activity) {
 		activity.overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left);
@@ -40,15 +44,22 @@ public final class NavUtil {
 
 	public static void startURL(Context context, Uri uri) {
 		Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-		intent.putExtra(Browser.EXTRA_APPLICATION_ID, context.getPackageName());
+		List<Intent> targetIntents = new ArrayList<Intent>();
 
-		if (uri.getHost().equals("repo.xposed.info")) {
-			Intent browser = new Intent(Intent.ACTION_VIEW, EXAMPLE_URI);
-			ComponentName browserApp = browser.resolveActivity(context.getPackageManager());
-			intent.setComponent(browserApp);
+		// Build a list of intents for activities that can open the URL, excluding this app
+		List<ResolveInfo> intentActivities = context.getPackageManager().queryIntentActivities(intent, 0);
+		for (ResolveInfo activityInfo : intentActivities) {
+			String packageName = activityInfo.activityInfo.packageName;
+			if (!packageName.equals(XPOSED_INSTALLER_PACKAGE_NAME)) {
+				Intent targetIntent = new Intent(Intent.ACTION_VIEW, uri);
+				targetIntent.setPackage(packageName);
+				targetIntents.add(targetIntent);
+			}
 		}
 
-		context.startActivity(intent);
+		Intent chooserIntent = Intent.createChooser(targetIntents.remove(0),context.getString(R.string.whichApplication));
+		chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, targetIntents.toArray(new Parcelable[targetIntents.size()]));
+		context.startActivity(chooserIntent);
 	}
 
 	public static void startURL(Context context, String url) {


### PR DESCRIPTION
If I understand the current code correctly, it serves the same purpose. however, it will fail if more than one browser (or any app that opens the example link) is installed.
This method should work in all cases.

Note: if you don't want to merge this, it's worth noting that the current method causes an FC for e.g. email addresses. This is fixed by checking if uri.getHost() is not null.
