### PR TITLE
Disable Fast Scroll in modules list

### DIFF
--- a/src/de/robv/android/xposed/installer/ModulesFragment.java
+++ b/src/de/robv/android/xposed/installer/ModulesFragment.java
@@ -86,7 +86,6 @@ public class ModulesFragment extends ListFragment implements ModuleListener {
 		reloadModules.run();
 		setListAdapter(mAdapter);
 		setEmptyText(getActivity().getString(R.string.no_xposed_modules_found));
-		getListView().setFastScrollEnabled(true);
 		registerForContextMenu(getListView());
 		mModuleUtil.addListener(this);
 


### PR DESCRIPTION
Upon attempting to fast scroll, the scroller disappears, this is probably because fast scroll categories haven't been implemented.

The fast scroll scroller also prevents the CheckBox from being easily clicked. Best to disable this for now.
