### PR TITLE
add module to "de.robv.android.xposed.installer.OPEN_SECTION" action

### DIFF
--- a/res/layout/xposed_show_all_modules.xml
+++ b/res/layout/xposed_show_all_modules.xml
@@ -1,0 +1,9 @@
+<Button xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:clickable="false"
+    android:focusable="false"
+    android:padding="3dp"
+    android:text="@string/show_all_modules"
+    android:textAppearance="?android:attr/textAppearanceMedium" />

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -92,6 +92,7 @@
     <string name="module_support">支持</string>
     <string name="module_app_info">程序信息</string>
     <string name="module_uninstall">卸载</string>
+    <string name="show_all_modules">显示所有模块</string>
 
     <!-- Download tab -->
     <string name="menuSearch">搜索</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -92,6 +92,7 @@
     <string name="module_support">Support</string>
     <string name="module_app_info">App info</string>
     <string name="module_uninstall">Uninstall</string>
+    <string name="show_all_modules">Show All Modules</string>
 
     <!-- Download tab -->
     <string name="menuSearch">Search</string>

--- a/src/de/robv/android/xposed/installer/ModulesFragment.java
+++ b/src/de/robv/android/xposed/installer/ModulesFragment.java
@@ -42,6 +42,7 @@ import de.robv.android.xposed.installer.util.ThemeUtil;
 public class ModulesFragment extends ListFragment implements ModuleListener {
 	public static final String SETTINGS_CATEGORY = "de.robv.android.xposed.category.MODULE_SETTINGS";
 	private static final String NOT_ACTIVE_NOTE_TAG = "NOT_ACTIVE_NOTE";
+	private static final String SHOW_ALL_MODULES = "SHOW_ALL_MODULES";
 	private static final String PLAY_STORE_PACKAGE = "com.android.vending";
 	private static final String PLAY_STORE_LINK = "https://play.google.com/store/apps/details?id=%s";
 	private static String PLAY_STORE_LABEL = null;
@@ -83,7 +84,16 @@ public class ModulesFragment extends ListFragment implements ModuleListener {
 		}
 
 		mAdapter = new ModuleAdapter(getActivity());
-		reloadModules.run();
+		String moduleName = getActivity().getIntent().getStringExtra("module");
+		if (moduleName != null && mModuleUtil.isInstalled(moduleName)) {
+			mAdapter.add(mModuleUtil.getModule(moduleName));
+			View showAllModules = getActivity().getLayoutInflater().inflate(
+					R.layout.xposed_show_all_modules, getListView(), false);
+			showAllModules.setTag(SHOW_ALL_MODULES);
+			getListView().addHeaderView(showAllModules);
+		} else {
+			reloadModules.run();
+		}
 		setListAdapter(mAdapter);
 		setEmptyText(getActivity().getString(R.string.no_xposed_modules_found));
 		registerForContextMenu(getListView());
@@ -147,6 +157,10 @@ public class ModulesFragment extends ListFragment implements ModuleListener {
 			Intent intent = new Intent(getActivity(), XposedInstallerActivity.class);
 			intent.putExtra(XposedInstallerActivity.EXTRA_SECTION, XposedDropdownNavActivity.TAB_INSTALL);
 			startActivity(intent);
+			return;
+		} else if (packageName.equals(SHOW_ALL_MODULES)) {
+			getListView().removeHeaderView(v);
+			getActivity().runOnUiThread(reloadModules);
 			return;
 		}
 


### PR DESCRIPTION
This patch add a extra "module" for the request module name, and will be much
easier for disabled xposed module to inform user to enable it in Xposed Installer.

Usage example:

```
Intent intent = new Intent("de.robv.android.xposed.installer.OPEN_SECTION");
intent.setPackage("de.robv.android.xposed.installer");
intent.putExtra("section", "modules");
intent.putExtra("module", getPackageName());
intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
startActivity(intent);
```
