### PR TITLE
check the module whether is actually loaded

### DIFF
--- a/src/de/robv/android/xposed/installer/util/ModuleUtil.java
+++ b/src/de/robv/android/xposed/installer/util/ModuleUtil.java
@@ -40,8 +40,8 @@ public final class ModuleUtil {
 	private final List<ModuleListener> mListeners = new CopyOnWriteArrayList<ModuleListener>();
 
 	public static int MIN_MODULE_VERSION = 2; // reject modules with xposedminversion below this
-	private long mtime = 0;
-	private HashSet<String> mModulesList = new HashSet<String>();
+	private static long mtime = 0;
+	private static HashSet<String> mModulesList = new HashSet<String>();
 	private static final String MODULES_LIST_FILE = XposedApp.BASE_DIR + "conf/modules.list";
 
 	private ModuleUtil() {


### PR DESCRIPTION
For some reason, the modules in the shared_prefrence are not the same with modules.list.
// for example, reboot too early or other possible problem.
However, the xposed bridge uses the modules.list, and xposed installer use shared_preference.
This patch makes a double check for the enabled modules, otherwise it will make user confused.

The C-part is not the same with Java-part, this is the main cause for MasterKey bug.
