### PR TITLE
Reload repo after changing global release type

### DIFF
--- a/src/de/robv/android/xposed/installer/util/RepoLoader.java
+++ b/src/de/robv/android/xposed/installer/util/RepoLoader.java
@@ -1,5 +1,12 @@
 package de.robv.android.xposed.installer.util;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.text.TextUtils;
+import android.widget.Toast;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -13,12 +20,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.text.TextUtils;
-import android.widget.Toast;
 import de.robv.android.xposed.installer.R;
 import de.robv.android.xposed.installer.XposedApp;
 import de.robv.android.xposed.installer.repo.Module;
@@ -107,6 +108,7 @@ public class RepoLoader {
 			@Override
 			public void run() {
 				RepoDb.updateAllModulesLatestVersion();
+                RepoLoader.getInstance().triggerReload(true);
 				notifyListeners();
 			}
 		}.start();


### PR DESCRIPTION
_Issue_
After changing the global release type setting the download versions list isn't updated.

_Usecase_
The user changes the global release type to see more module versions. After changing the settings the user goes to the modules download list and doesn't see any difference. He needs to manually refresh the modules list to see all versions. This is inconsistent to the behaviour of local release type changes.
This particular usecase was reported in the Xposed Installer experimental1 xda thread.

_Possible resolution_
Trigger a repro loader reload after global release type change.
