### PR TITLE
Make default theme in manifest Light

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.Dark"
+        android:theme="@style/Theme.Light"
         android:name=".XposedApp" >
 
         <activity


### PR DESCRIPTION
I changed the theme for the app to Light since the default theme is
light. This means it won't flash black when opening the app
However, it means it will flash white if the user uses dark theme
I still think it's better because light is default
