### PR TITLE
fix possible optimizing when using soft reboot

### DIFF
--- a/src/de/robv/android/xposed/installer/InstallerFragment.java
+++ b/src/de/robv/android/xposed/installer/InstallerFragment.java
@@ -804,7 +804,7 @@ public class InstallerFragment extends Fragment {
 			return;
 
 		List<String> messages = new LinkedList<String>();
-		if (mRootUtil.execute("setprop ctl.restart surfaceflinger; setprop ctl.restart zygote", messages) != 0) {
+		if (mRootUtil.execute("setprop ctl.restart surfaceflinger", messages) != 0) {
 			messages.add("");
 			messages.add(getString(R.string.reboot_failed));
 			showAlert(TextUtils.join("\n", messages).trim());

--- a/src/de/robv/android/xposed/installer/util/NotificationUtil.java
+++ b/src/de/robv/android/xposed/installer/util/NotificationUtil.java
@@ -149,7 +149,7 @@ public final class NotificationUtil {
 			List<String> messages = new LinkedList<String>();
 			boolean isSoftReboot = intent.getBooleanExtra(EXTRA_SOFT_REBOOT, false);
 			int returnCode = isSoftReboot ?
-				  rootUtil.execute("setprop ctl.restart surfaceflinger; setprop ctl.restart zygote", messages)
+				  rootUtil.execute("setprop ctl.restart surfaceflinger", messages)
 				: rootUtil.executeWithBusybox("reboot", messages);
 
 			if (returnCode != 0) {


### PR DESCRIPTION
android 5.1 add `.booting` for zygote, which can prevent boot loops.
https://android.googlesource.com/platform/art/+/android-5.1.1_r9/runtime/gc/space/image_space.cc#124

The soft reboot restarts `surfaceflinger` and `zygote`, actually, the `surfaceflinger` will restart `zygote` too. So the soft reboot *may* restart `zygote` twice, will prune the dalvik cache.

Furthremore, I think it's not a good idea for soft reboot and reboot depends the su. So I write a xposed mod, allow soft reboot and reboot without su. If you like this idea, I will add a pull request too. For the source, please visit: https://github.com/liudongmiao/RebootWithoutSu

As the xposed installer doesn't declare permission, so I keep the permission in `RebootWithoutSu` empty, which is a security hole.