### PR TITLE
Enable copying text from Logs screen

### DIFF
--- a/src/de/robv/android/xposed/installer/LogsFragment.java
+++ b/src/de/robv/android/xposed/installer/LogsFragment.java
@@ -48,6 +48,7 @@ public class LogsFragment extends Fragment {
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		View v = inflater.inflate(R.layout.tab_logs, container, false);
 		mTxtLog = (TextView) v.findViewById(R.id.txtLog);
+		mTxtLog.setTextIsSelectable(true);
 		mSVLog = (ScrollView) v.findViewById(R.id.svLog);
 		mHSVLog = (HorizontalScrollView) v.findViewById(R.id.hsvLog);
 		reloadErrorLog();


### PR DESCRIPTION
Now, you can't press on the Xposed logs to copy some lines (show text processing panel). With this patch, we can select and copy what we want. We don't have to do it longer way: export the Xposed log, find the log file, open a text editor, select part of the logs to copy.

p.s: consider to unblock me - @pylerSM account. I tried even push Lollipop 5.1 fixes for AppSettings but I can't since you blocked me from all your repositories.