### PR TITLE
Enable copying text from Logs screen

### DIFF
--- a/res/layout/tab_logs.xml
+++ b/res/layout/tab_logs.xml
@@ -13,7 +13,8 @@
             android:id="@+id/txtLog"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:padding="8dp" />
+            android:padding="8dp"
+            android:textIsSelectable="true" />
     </HorizontalScrollView>
 
 </ScrollView>


### PR DESCRIPTION
Currently, you can't press on the Xposed logs to copy some lines (show text processing panel). With this patch, we can select and copy what we want. We don't have to do it longer way: export the Xposed log, find the log file, open a text editor, select part of the logs to copy.
