### PR TITLE
Fix Crash at Open

### DIFF
--- a/app/src/main/java/de/robv/android/xposed/installer/util/DownloadsUtil.java
+++ b/app/src/main/java/de/robv/android/xposed/installer/util/DownloadsUtil.java
@@ -122,7 +122,7 @@ public class DownloadsUtil {
         Context context = XposedApp.getInstance();
         ArrayList<File> dirs = new ArrayList<>(2);
         for (File dir :  ContextCompat.getExternalCacheDirs(context)) {
-            if (Environment.MEDIA_MOUNTED.equals(EnvironmentCompat.getStorageState(dir))) {
+            if ((dir != null) && (Environment.MEDIA_MOUNTED.equals(EnvironmentCompat.getStorageState(dir)))) {
                 dirs.add(new File(new File(dir, "downloads"), subDir));
             }
         }


### PR DESCRIPTION
`dir` could be null. That's why many devices such as Samsung and Meizu crash.

Confirmed working on many Meizu devices.

Fix https://github.com/rovo89/Xposed/issues/194
