### PR TITLE
Add Magisk systemless support

### DIFF
--- a/app/src/main/java/de/robv/android/xposed/installer/XposedApp.java
+++ b/app/src/main/java/de/robv/android/xposed/installer/XposedApp.java
@@ -41,7 +41,7 @@ public class XposedApp extends Application implements ActivityLifecycleCallbacks
     public static final String ENABLED_MODULES_LIST_FILE = XposedApp.BASE_DIR + "conf/enabled_modules.list";
 
     private static final String[] XPOSED_PROP_FILES = new String[]{
-            "/su/xposed/xposed.prop", // official systemless
+            "/sbin/xposed.prop",      // official systemless
             "/system/xposed.prop",    // classical
     };
 


### PR DESCRIPTION
Hello @rovo89, long time no see! In the time since last time we had conversation here on Github (for systemless support of Xposed), I had created a quite popular project [Magisk]( https://github.com/topjohnwu/Magisk), which basically is another root method, but most importantly provides a simple, easy to use systemless interface.

The first few systemless versions of Xposed by me requires quite a few adjustments for several paths, and has some rough edges. However since recent versions of **Magisk**, the interface itself is much more advanced, and can handle adding tons of additional files into `/system` without issues. The result is that Xposed binaries do not need to be modified - you just need to place them in the right place, and **Magisk** will mount the files to the target location for you.

However, one small issue appears: for the prop file `/system/xposed.prop`, some devices cannot handle adding files to system root. I do not want to recompile `app_process` just to change this single path, as a temporary solution, I ended up hex editing the binaries to load from `/xposed.prop`, which actually links to `/magisk/xposed_<sdk>/xposed.prop`. The reason for choosing `/xposed.prop` is simply due the fact that it's shorter than `/system/xposed.prop`.
BTW, it is also trivial to add the patch to the native Xposed source, you can consider adding the path `/magisk/xposed_<sdk>/xposed.prop` (or `/xposed.prop` if you're lazy lol) to one of the lookup paths for the prop file.

Since I am the maintainer of all systemless versions, I think it would be reasonable to add the prop path to the main app (thus this PR), and the patch is extremely trivial. 

On another topic, my experience with **SuperSU** using the `post-fs-data` mode doesn't work reliably (which is the initial motivation to create **Magisk**), and since it is only a barebone rooting solution, many adjustments has to be done (just like my early versions of Systemless Xposed). I'm not sure what you plan is, but I would suggest that it will be a better idea to make the "official" systemless version as a Magisk module. In addition, my project is 100% open source, so you wouldn't need to depend on proprietary SuperSU 😉

For more info regarding systemless Xposed, check out my [XDA Thread](https://forum.xda-developers.com/showthread.php?p=67074423#post67074423)
SDK 25 version of systemless Xposed on my [Magisk Online Repo](https://github.com/Magisk-Modules-Repo/xposed_25)