### PR TITLE
Add simple splash screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,16 +16,19 @@
         android:label="@string/app_name"
         android:theme="@style/Theme.XposedInstaller.Light">
         <activity
-            android:name=".WelcomeActivity"
-            android:configChanges="orientation|screenSize"
-            android:exported="true"
-            android:label="@string/app_name">
+            android:name=".SplashActivity"
+            android:theme="@style/Theme.XposedInstaller.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity
+            android:name=".WelcomeActivity"
+            android:configChanges="orientation|screenSize"
+            android:exported="true"
+            android:label="@string/app_name" />
         <activity
             android:name=".DownloadDetailsActivity"
             android:configChanges="orientation|screenSize"

--- a/app/src/main/java/de/robv/android/xposed/installer/SplashActivity.java
+++ b/app/src/main/java/de/robv/android/xposed/installer/SplashActivity.java
@@ -1,0 +1,20 @@
+package de.robv.android.xposed.installer;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class SplashActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Clone intent to pass on filter information
+        // such as intent action for launcher shortcuts
+        Intent intent = getIntent().cloneFilter();
+        intent.setClass(this, WelcomeActivity.class);
+        startActivity(intent);
+        finish();
+    }
+}

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -31,7 +31,11 @@
         <item name="background_card_pressed">@drawable/background_card_pressed_black</item>
     </style>
 
-    <style name="Theme.XposedInstaller.Transparent" parent="Theme.AppCompat.NoActionBar">
+    <style name="Theme.XposedInstaller.Splash" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowBackground">@color/background_material_dark</item>
+        <item name="android:statusBarColor">@color/background_material_dark</item>
     </style>
+
+    <style name="Theme.XposedInstaller.Transparent" parent="Theme.AppCompat.NoActionBar" />
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -44,6 +44,10 @@
         <item name="background_card_pressed">@drawable/background_card_pressed_black</item>
     </style>
 
+    <style name="Theme.XposedInstaller.Splash" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowBackground">@color/background_material_dark</item>
+    </style>
+
     <style name="Theme.XposedInstaller.Toolbar" parent="ThemeOverlay.AppCompat.Light">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="android:textColorPrimary">@android:color/white</item>
@@ -51,7 +55,6 @@
         <item name="android:textColorSecondary">@android:color/white</item>
     </style>
 
-    <style name="Theme.XposedInstaller.Transparent" parent="Theme.AppCompat.NoActionBar">
-    </style>
+    <style name="Theme.XposedInstaller.Transparent" parent="Theme.AppCompat.NoActionBar" />
 
 </resources>


### PR DESCRIPTION
This PR adds a simple splash screen with a dark color.

It works by setting the lightweight SplashActivity as the default activity in the manifest. This way, the white screen that would be visible on slower devices when the "heavy" activity takes some time to be drawn doesn't appear and is instead replaced with a darker color.

The reason why I like this approach instead of "fancier" splash screens (the ones with a logo or loading animation) is that those make the app _seem_ to open slower, even when they're properly implemented and the app opens just as fast as it did before.

Another reason is because this approach solves a more prominent problem than wanting to show the users something to look at while the program loads: it replaces the white screen that would be there otherwise and burns the eyes of those which have chosen the dark theme in the settings, hoping that their retinas would be spared this way.

Also, I needed another PR to finish the #Hacktoberfest challenge ^^

Screenshot: https://imgur.com/a/S8Lma
This PR can be cherry-picked and merges without conflicts with my other PR.