### PR TITLE
Correcting the Redirect issue from HTTP to HTTPS.

### DIFF
--- a/app/src/main/java/de/robv/android/xposed/installer/util/RepoLoader.java
+++ b/app/src/main/java/de/robv/android/xposed/installer/util/RepoLoader.java
@@ -32,7 +32,7 @@ import de.robv.android.xposed.installer.repo.Repository;
 import de.robv.android.xposed.installer.util.DownloadsUtil.SyncDownloadInfo;
 
 public class RepoLoader extends OnlineLoader<RepoLoader> {
-    private static final String DEFAULT_REPOSITORIES = "http://dl.xposed.info/repo/full.xml.gz";
+    private static final String DEFAULT_REPOSITORIES = "https://dl-xda.xposed.info/repo/full.xml.gz";
     private static RepoLoader mInstance = null;
     private static final XposedApp sApp = XposedApp.getInstance();
     private final Map<String, ReleaseType> mLocalReleaseTypesCache = new HashMap<>();


### PR DESCRIPTION
A fix to accommodate the changes made by @Rovo89 whereas he had enforced HTTPS on the server, but the HttpURLConnection class used by the Xposed Installer has issues with following redirects from HTTP to HTTPS.